### PR TITLE
Greenkeeper doesn't work with `npm ci`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: false
 notifications:
   email: false
 if: tag IS blank
+
+install: case $TRAVIS_BRANCH in greenkeeper*) npm i;; *) npm ci;; esac;
 before_script:
   - ARTIFACT_PATH="./`node ./scripts/version`"
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.1.5] - 2018-11-17
+
+### Changed
+
+- Using a workaround in travis' configuration since greenkeeper doesn't work with `npm ci` (see: https://github.com/greenkeeperio/greenkeeper-lockfile/issues/156)
+
 ## [0.1.4] - 2018-11-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
     "vscode:prepublish": "npm run compile",
     "watch": "tsc -watch -p ./"
   },
-  "version": "0.1.4"
+  "version": "0.1.5"
 }


### PR DESCRIPTION
Workaround: https://github.com/greenkeeperio/greenkeeper-lockfile/issues/156#issuecomment-397719017